### PR TITLE
Bump version of framework and dependencies

### DIFF
--- a/src/IndentRainbow.Extension/IndentRainbow.Extension.csproj
+++ b/src/IndentRainbow.Extension/IndentRainbow.Extension.csproj
@@ -33,7 +33,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IndentRainbow.Extension</RootNamespace>
-    <AssemblyName>IndentRainbow</AssemblyName>
+    <AssemblyName>IndentRainbow.Extension</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>

--- a/src/IndentRainbow.Extension/IndentRainbow.Extension.csproj
+++ b/src/IndentRainbow.Extension/IndentRainbow.Extension.csproj
@@ -127,10 +127,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.8.37222</Version>
+      <Version>17.14.40265</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.8.2365</Version>
+      <Version>17.14.2094</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/IndentRainbow.Logic/IndentRainbow.Logic.csproj
+++ b/src/IndentRainbow.Logic/IndentRainbow.Logic.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IndentRainbow.Logic</RootNamespace>
     <AssemblyName>IndentRainbow.Logic</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/tests/IndentRainbow.Logic.Tests/IndentRainbow.Logic.Tests.csproj
+++ b/tests/IndentRainbow.Logic.Tests/IndentRainbow.Logic.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IndentRainbow.Logic.Tests</RootNamespace>
     <AssemblyName>IndentRainbow.Logic.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -19,6 +19,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/IndentRainbow.Logic.Tests/IndentRainbow.Logic.Tests.csproj
+++ b/tests/IndentRainbow.Logic.Tests/IndentRainbow.Logic.Tests.csproj
@@ -58,21 +58,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.18.4</Version>
+      <Version>4.20.72</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.0.2</Version>
+      <Version>3.9.3</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="WindowsBase">
-      <Version>4.6.1055</Version>
+      <Version>3.9.3</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tests/IndentRainbow.Logic.Tests/app.config
+++ b/tests/IndentRainbow.Logic.Tests/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.10.0.0" newVersion="4.10.0.0" />
+        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.10.0.0" newVersion="4.10.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
This PR updates us onto .NET Framework 4.8 and bumps all dependencies to unblock the CI.